### PR TITLE
core: migrate to libsql-sys

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.28"
-sqlite3-sys = "0.15.2"
+libsql-sys = "0.1.1"
 thiserror = "1.0.40"

--- a/crates/core/examples/example.rs
+++ b/crates/core/examples/example.rs
@@ -3,6 +3,8 @@ use libsql_core::Database;
 fn main() {
     let db = Database::open(":memory:");
     let conn = db.connect().unwrap();
-    conn.execute("CREATE TABLE IF NOT EXISTS users (email TEXT)").unwrap();
-    conn.execute("INSERT INTO users (email) VALUES ('alice@example.org')").unwrap();
+    conn.execute("CREATE TABLE IF NOT EXISTS users (email TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO users (email) VALUES ('alice@example.org')")
+        .unwrap();
 }


### PR DESCRIPTION
There was a weird friction regarding error types,
but it's really minor, and it will be fixed once we abstract it away with something like rusqlite.